### PR TITLE
Encoding issue in pull.py

### DIFF
--- a/lib/ansible/cli/pull.py
+++ b/lib/ansible/cli/pull.py
@@ -245,7 +245,7 @@ class PullCLI(CLI):
                 display.warning("Unable to update repository. Continuing with (forced) run of playbook.")
             else:
                 return rc
-        elif self.options.ifchanged and '"changed": true' not in out:
+        elif self.options.ifchanged and b'"changed": true' not in out:
             display.display("Repository has not changed, quitting.")
             return 0
 


### PR DESCRIPTION
##### SUMMARY
Looking at `run_cmd`, the output should always be `bytes`, not `str` - so we'll need to search for `bytes`, too.

##### ISSUE TYPE
 - Bugfix Pull Request

##### COMPONENT NAME
ansible-pull

##### ANSIBLE VERSION
```
ansible 2.4.3.0
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.5/dist-packages/ansible
  executable location = /usr/local/bin/ansible
  python version = 3.5.2 (default, Nov 23 2017, 16:37:01) [GCC 5.4.0 20160609]
```

##### ADDITIONAL INFORMATION
This is the error.
```
ERROR! Unexpected Exception, this is probably a bug: a bytes-like object is required, not 'str'
```

I have not done any testing on Python 2. But as `run_cmd` explicitly initializes `stdout` to `b''`, I suspect that it is supposed to return `bytes` - hence the fix as is.
